### PR TITLE
fix: Do not install weak deps for RPM prereqs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,9 +2,10 @@
 name: "CI - Test Features"
 # yamllint disable-line rule:truthy
 on:
-  push:
-    branches:
-      - main
+  # TODO @memes - re-enable on push to main if force pushes need to be allowed
+  # push:
+  #   branches:
+  #     - main
   pull_request:
   workflow_dispatch:
 

--- a/src/buf/install.sh
+++ b/src/buf/install.sh
@@ -25,7 +25,7 @@ prereqs() {
             apk --no-cache add "$@" || error "Failed to install apks for $*"
             ;;
         *rhel*|*fedora*)
-            dnf install -y "$@" || error "Failed to install rpms for $*"
+            dnf install -y --setopt=install_weak_deps=False "$@" || error "Failed to install rpms for $*"
             rm -rf /var/cache/dnf/* /var/cache/yum/*
             ;;
         *debian*|*ubuntu*)

--- a/src/direnv/install.sh
+++ b/src/direnv/install.sh
@@ -27,7 +27,7 @@ prereqs() {
             apk --no-cache add "$@" || error "Failed to install apks for $*"
             ;;
         *rhel*|*fedora*)
-            dnf install -y "$@" || error "Failed to install rpms for $*"
+            dnf install -y --setopt=install_weak_deps=False "$@" || error "Failed to install rpms for $*"
             rm -rf /var/cache/dnf/* /var/cache/yum/*
             ;;
         *debian*|*ubuntu*)

--- a/src/flux/install.sh
+++ b/src/flux/install.sh
@@ -25,7 +25,7 @@ prereqs() {
             apk --no-cache add "$@" || error "Failed to install apks for $*"
             ;;
         *rhel*|*fedora*)
-            dnf install -y "$@" || error "Failed to install rpms for $*"
+            dnf install -y --setopt=install_weak_deps=False "$@" || error "Failed to install rpms for $*"
             rm -rf /var/cache/dnf/* /var/cache/yum/*
             ;;
         *debian*|*ubuntu*)

--- a/src/gcrane/install.sh
+++ b/src/gcrane/install.sh
@@ -25,7 +25,7 @@ prereqs() {
             apk --no-cache add "$@" || error "Failed to install apks for $*"
             ;;
         *rhel*|*fedora*)
-            dnf install -y "$@" || error "Failed to install rpms for $*"
+            dnf install -y --setopt=install_weak_deps=False "$@" || error "Failed to install rpms for $*"
             rm -rf /var/cache/dnf/* /var/cache/yum/*
             ;;
         *debian*|*ubuntu*)

--- a/src/golangci-lint/install.sh
+++ b/src/golangci-lint/install.sh
@@ -26,7 +26,7 @@ prereqs() {
             apk --no-cache add "$@" || error "Failed to install apks for $*"
             ;;
         *rhel*|*fedora*)
-            dnf install -y "$@" || error "Failed to install rpms for $*"
+            dnf install -y --setopt=install_weak_deps=False "$@" || error "Failed to install rpms for $*"
             rm -rf /var/cache/dnf/* /var/cache/yum/*
             ;;
         *debian*|*ubuntu*)

--- a/src/google-cloud-cli/install.sh
+++ b/src/google-cloud-cli/install.sh
@@ -28,7 +28,7 @@ prereqs() {
             apk --no-cache add "$@" || error "Failed to install apks for $*"
             ;;
         *rhel*|*fedora*)
-            dnf install -y "$@" || error "Failed to install rpms for $*"
+            dnf install -y --setopt=install_weak_deps=False "$@" || error "Failed to install rpms for $*"
             rm -rf /var/cache/dnf/* /var/cache/yum/*
             ;;
         *debian*|*ubuntu*)

--- a/src/goreleaser/install.sh
+++ b/src/goreleaser/install.sh
@@ -27,7 +27,7 @@ prereqs() {
             apk --no-cache add "$@" || error "Failed to install apks for $*"
             ;;
         *rhel*|*fedora*)
-            dnf install -y "$@" || error "Failed to install rpms for $*"
+            dnf install -y --setopt=install_weak_deps=False "$@" || error "Failed to install rpms for $*"
             rm -rf /var/cache/dnf/* /var/cache/yum/*
             ;;
         *debian*|*ubuntu*)

--- a/src/hadolint/install.sh
+++ b/src/hadolint/install.sh
@@ -25,7 +25,7 @@ prereqs() {
             apk --no-cache add "$@" || error "Failed to install apks for $*"
             ;;
         *rhel*|*fedora*)
-            dnf install -y "$@" || error "Failed to install rpms for $*"
+            dnf install -y --setopt=install_weak_deps=False "$@" || error "Failed to install rpms for $*"
             rm -rf /var/cache/dnf/* /var/cache/yum/*
             ;;
         *debian*|*ubuntu*)

--- a/src/hashicorp/install.sh
+++ b/src/hashicorp/install.sh
@@ -23,7 +23,7 @@ prereqs() {
             apk --no-cache add "$@" || error "Failed to install apks for $*"
             ;;
         *rhel*|*fedora*)
-            dnf install -y "$@" || error "Failed to install rpms for $*"
+            dnf install -y --setopt=install_weak_deps=False "$@" || error "Failed to install rpms for $*"
             rm -rf /var/cache/dnf/* /var/cache/yum/*
             ;;
         *debian*|*ubuntu*)

--- a/src/opentofu/install.sh
+++ b/src/opentofu/install.sh
@@ -27,7 +27,7 @@ prereqs() {
             apk --no-cache add "$@" || error "Failed to install apks for $*"
             ;;
         *rhel*|*fedora*)
-            dnf install -y "$@" || error "Failed to install rpms for $*"
+            dnf install -y --setopt=install_weak_deps=False "$@" || error "Failed to install rpms for $*"
             rm -rf /var/cache/dnf/* /var/cache/yum/*
             ;;
         *debian*|*ubuntu*)

--- a/src/sops/install.sh
+++ b/src/sops/install.sh
@@ -27,7 +27,7 @@ prereqs() {
             apk --no-cache add "$@" || error "Failed to install apks for $*"
             ;;
         *rhel*|*fedora*)
-            dnf install -y "$@" || error "Failed to install rpms for $*"
+            dnf install -y --setopt=install_weak_deps=False "$@" || error "Failed to install rpms for $*"
             rm -rf /var/cache/dnf/* /var/cache/yum/*
             ;;
         *debian*|*ubuntu*)

--- a/src/starship/install.sh
+++ b/src/starship/install.sh
@@ -27,7 +27,7 @@ prereqs() {
             apk --no-cache add "$@" || error "Failed to install apks for $*"
             ;;
         *rhel*|*fedora*)
-            dnf install -y "$@" || error "Failed to install rpms for $*"
+            dnf install -y --setopt=install_weak_deps=False "$@" || error "Failed to install rpms for $*"
             rm -rf /var/cache/dnf/* /var/cache/yum/*
             ;;
         *debian*|*ubuntu*)

--- a/src/talisman/install.sh
+++ b/src/talisman/install.sh
@@ -25,7 +25,7 @@ prereqs() {
             apk --no-cache add "$@" || error "Failed to install apks for $*"
             ;;
         *rhel*|*fedora*)
-            dnf install -y "$@" || error "Failed to install rpms for $*"
+            dnf install -y --setopt=install_weak_deps=False "$@" || error "Failed to install rpms for $*"
             rm -rf /var/cache/dnf/* /var/cache/yum/*
             ;;
         *debian*|*ubuntu*)

--- a/src/terraform-docs/install.sh
+++ b/src/terraform-docs/install.sh
@@ -25,7 +25,7 @@ prereqs() {
             apk --no-cache add "$@" || error "Failed to install apks for $*"
             ;;
         *rhel*|*fedora*)
-            dnf install -y "$@" || error "Failed to install rpms for $*"
+            dnf install -y --setopt=install_weak_deps=False "$@" || error "Failed to install rpms for $*"
             rm -rf /var/cache/dnf/* /var/cache/yum/*
             ;;
         *debian*|*ubuntu*)

--- a/src/terragrunt/install.sh
+++ b/src/terragrunt/install.sh
@@ -25,7 +25,7 @@ prereqs() {
             apk --no-cache add "$@" || error "Failed to install apks for $*"
             ;;
         *rhel*|*fedora*)
-            dnf install -y "$@" || error "Failed to install rpms for $*"
+            dnf install -y --setopt=install_weak_deps=False "$@" || error "Failed to install rpms for $*"
             rm -rf /var/cache/dnf/* /var/cache/yum/*
             ;;
         *debian*|*ubuntu*)

--- a/src/tflint/install.sh
+++ b/src/tflint/install.sh
@@ -25,7 +25,7 @@ prereqs() {
             apk --no-cache add "$@" || error "Failed to install apks for $*"
             ;;
         *rhel*|*fedora*)
-            dnf install -y "$@" || error "Failed to install rpms for $*"
+            dnf install -y --setopt=install_weak_deps=False "$@" || error "Failed to install rpms for $*"
             rm -rf /var/cache/dnf/* /var/cache/yum/*
             ;;
         *debian*|*ubuntu*)

--- a/src/vesctl/install.sh
+++ b/src/vesctl/install.sh
@@ -25,7 +25,7 @@ prereqs() {
             apk --no-cache add "$@" || error "Failed to install apks for $*"
             ;;
         *rhel*|*fedora*)
-            dnf install -y "$@" || error "Failed to install rpms for $*"
+            dnf install -y --setopt=install_weak_deps=False "$@" || error "Failed to install rpms for $*"
             rm -rf /var/cache/dnf/* /var/cache/yum/*
             ;;
         *debian*|*ubuntu*)


### PR DESCRIPTION
Prerequisite packages for Fedora/UBI were including weak dependencies which make the resulting devcontainer larger and increases the time for testing. This change adds setopt flag to disable weak deps when installing prereqs.

test: Do not test on push to main