### PR TITLE
docs(google-cloud-cli): Update NOTES

### DIFF
--- a/src/google-cloud-cli/NOTES.md
+++ b/src/google-cloud-cli/NOTES.md
@@ -18,8 +18,8 @@ directories.
         }
     },
     "mounts": [
-        "source=${localEnv:HOME}/.config/gcloud,target=/home/vscode/.config/gcloud,type=bind",
-        "source=${localEnv:HOME}${localEnv:USERPROFILE}/.ssh,target=/home/vscode/.ssh,type=bind,readonly"
+        "source=${localEnv:HOME}/.config/gcloud,target=/home/vscode/.config/gcloud,type=bind,consistency=cached",
+        "source=${localEnv:HOME}${localEnv:USERPROFILE}/.ssh,target=/home/vscode/.ssh,type=bind,consistency=cached,readonly"
     ]
 }
 ```


### PR DESCRIPTION
Add flag to cache the SSH and GCP mounts.